### PR TITLE
initial impl of symbol lookup

### DIFF
--- a/include/ast.h
+++ b/include/ast.h
@@ -7,7 +7,7 @@
 struct node;
 
 typedef enum {
-    AST_STRING, AST_NUMBER, AST_LIST, AST_SYMBOL, AST_QUOTED
+    AST_STRING, AST_NUMBER, AST_LIST, AST_SYMBOL, AST_QUOTED, AST_LAMBDA
 } ast_type_t;
 
 typedef struct {
@@ -22,6 +22,11 @@ typedef struct ll {
     struct node* car; 
     struct ll* cdr; 
 } ast_node_list_t;
+
+typedef struct node *(*lambda)(ast_node_list_t*);
+typedef struct {
+    lambda function;
+} ast_node_lambda_t;
 
 typedef struct {
     char* value;
@@ -39,6 +44,7 @@ typedef struct node {
         ast_node_number_t* number;
         ast_node_list_t* list;
         ast_node_quoted_t* quoted;
+        ast_node_lambda_t* lambda;
     } value;
 } node_t;
 
@@ -51,6 +57,7 @@ node_t* mkQuoted(node_t* child);
 node_t* mkNodeString(char* str);
 node_t* mkNodeSymbol(char* str);
 node_t* mkNodeNumber(int64_t num);
+node_t* mkNodeLambda(lambda fn);
 ast_node_list_t* cons(node_t* car, ast_node_list_t* cdr);
 ast_node_list_t* append(node_t* value, ast_node_list_t* list);
 ast_node_list_t* tail(ast_node_list_t* list);

--- a/include/eval.h
+++ b/include/eval.h
@@ -9,14 +9,9 @@
 #define AS_STRING(node) (node->value.string->value)
 #define AS_NUMBER(node) (node->value.number->value)
 
-typedef node_t *(*fn)(ast_node_list_t*);
-
 typedef struct {
     char* name;
-    union {
-        fn function;
-        node_t* data;
-    } value;
+    node_t* data;
 } context_obj_t;
 
 typedef struct {
@@ -33,10 +28,5 @@ node_t* lispPrint(ast_node_list_t*);
 node_t* lispAdd(ast_node_list_t*);
 context_t* defaultEnv(void);
 void freeContext(context_t*);
-
-static context_obj_t print = {.name = "print", .value.function = &lispPrint};
-static context_obj_t add = {.name = "+", .value.function = &lispAdd};
-
-static context_obj_t* builtins[] = { &print, &add, NULL };
 
 #endif

--- a/src/ast.c
+++ b/src/ast.c
@@ -22,6 +22,17 @@ node_t* mkNodeString(char* str) {
     return node;
 }
 
+node_t* mkNodeLambda(lambda fn) {
+  node_t* node = mkNode(AST_LAMBDA);
+
+  ast_node_lambda_t* lambda = malloc(sizeof(ast_node_lambda_t));
+  lambda->function = fn;
+
+  node->value.lambda = lambda;
+
+  return node;
+}
+
 node_t* mkNodeSymbol(char* str) {
     node_t* node = mkNode(AST_SYMBOL);
 


### PR DESCRIPTION
Kind of abused the AST to treat our inbuilt functions as lambdas and as any other type of data. I think this is what you meant when we we're initially adding it? (so first they're first class now)

added `version` as a in built data just to test the lookup!

```lisp
zeptolisp version: add-symbol-lookup-1889069

> (print version)
add-symbol-lookup-1889069
=> nil
> (version "a")
version is not a function
```